### PR TITLE
tag-key-bytes: Tag.key as bytes

### DIFF
--- a/storage/CHANGELOG.md
+++ b/storage/CHANGELOG.md
@@ -6,7 +6,7 @@
 - [Breaking] Return piece CIDs in `SearchResult`.
 - Added the option `Query.skipData` to fetch piece metadata without payload data in search results.
 - Added the option `Tag.searchable` to specify whether or not a tag should be indexed for fast search.
-- `Tag.value` is now bytes instead of string.
+- `Tag.key` and `Tag.value` may contain bytes instead of only string.
 - Added a table of known tags.
 
 ### v0.1.2

--- a/storage/protobuf/tag.proto
+++ b/storage/protobuf/tag.proto
@@ -23,9 +23,9 @@ option go_package = "/pb";
  * Below is the structure of a tag:
  */
 message Tag {
-  // The key of the tag. The key should start with a letter (a-zA-Z).
-  string        key           = 1;
-  // The value of the tag for this key.
+  // The key of the tag. It is usually a UTF-8 string, but it may be any data.
+  bytes         key           = 1;
+  // The value of the tag for this key. The value should be interpreted based on the key.
   bytes         value         = 2;
   // Whether this tag is searchable or not. Yes by default.
   SearchType    searchable    = 3;


### PR DESCRIPTION
Follow-up to the change of Tag. value as bytes.