### PR TITLE
signature-message: spec of signatures v0.1.4

### DIFF
--- a/storage/CHANGELOG.md
+++ b/storage/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNext
 - `SignedPiece.piece` is embedded as a serialized message.
+- Improved security and performance of signed upload requests.
 
 ### v0.1.3
 - [Breaking] Return piece CIDs in `SearchResult`.

--- a/storage/protobuf/signature.proto
+++ b/storage/protobuf/signature.proto
@@ -6,11 +6,51 @@ option go_package = "/pb";
 
 /*
  * A signature and details to help verify it.
+ * 
+ * #### Generation
+ *
+ * - Compute a CID from the `piece` bytes using details from `signature`:
+ *     - [CIDv1](https://github.com/multiformats/cid).
+ *     - The hash function should be blake2b-256 and `multiHashType` should be empty.
+ *     - Content type codec `0x55`
+ *     - Base encoded in Base32 with the prefix `b`
+ *     - Example: bafk2bzacea73ycjnxe2qov7cvnhx52lzfp6nf5jcblnfus6gqreh6ygganbws
+ *
+ * - Store the public key of the signer in `publicKey` in binary encoding.
+ *
+ * - Store the current time in `timeMs`
+ *     - In JavaScript: `timeMs = +new Date()`
+ *
+ * - Format the current time in ISO 8601 `YYYY-MM-DDTHH:mm:ss.sssZ`
+       - In JavaScript: `timeText = new Date(timeMs).toISOString()`
+       - In Go format: `2006-01-02T15:04:05.000Z`
+ *
+ * - The signed message of the upload of a piece is:
+ *     - `<Bytes>DDC upload ${CID} at ${timeText}</Bytes>`
+ *     - Note: the `<Bytes>` part is enforced by the Polkadot.js browser extension.
+ *     - Example: `<Bytes>DDC upload bafk2bzacea73ycjnxe2qov7cvnhx52lzfp6nf5jcblnfus6gqreh6ygganbws at 2022-06-27T07:33:44.607Z</Bytes>`
+ *
+ * - The signing scheme should be sr25519, and `scheme` should be empty.
+ *     - If this not supported by a signer, then `scheme` should be "ed25519".
+ *
+ * - Sign and store the signature in `sig` in binary encoding.
+ * 
+ * #### Verification
+ * 
+ * - Recompute the signed message using the details in `signature`.
+ * - Verify `sig` given the scheme, the message, and the public key.
+ * 
+ * #### Legacy signatures before v0.1.4
+ * 
+ * If `signer` and `value` are present:
+ * - Decode them from hexadecimal with or without `0x`, instead of `publicKey` and `sig`.
+ * - The signed message is `${CID}` or `<Bytes>${CID}</Bytes>`.
+ *
  */
 message Signature {
-  // A cryptographic signature.
+  // [deprecated] A cryptographic signature in hexadecimal with or without "0x".
   string value         = 1;
-  // The public key of the signer.
+  // [deprecated] The public key of the signer in hexadecimal with or without "0x".
   string signer        = 2;
   // The name of the signature scheme (sr25519, secp256k1, ed25519).
   // Default and recommended value: "" or "sr25519".
@@ -18,4 +58,10 @@ message Signature {
   // The ID of the hashing algorithm as per multiformats/multihash.
   // Default and recommended value: 0 or 0xb220, meaning blake2b-256.
   uint64 multiHashType = 4;
+  // The timestamp in UNIX milliseconds.
+  uint64 timeMs        = 5;
+  // The public key in binary encoding as per the scheme.
+  bytes publicKey      = 6;
+  // The cryptographic signature in binary encoding as per the scheme.
+  bytes sig            = 7;
 }

--- a/storage/protobuf/signature.proto
+++ b/storage/protobuf/signature.proto
@@ -18,17 +18,17 @@ option go_package = "/pb";
  *
  * - Store the public key of the signer in `publicKey` in binary encoding.
  *
- * - Store the current time in `timeMs`
- *     - In JavaScript: `timeMs = +new Date()`
+ * - Store the current time in `timestamp`
+ *     - In JavaScript: `timestamp = +new Date()`
  *
  * - Format the current time in ISO 8601 `YYYY-MM-DDTHH:mm:ss.sssZ`
-       - In JavaScript: `timeText = new Date(timeMs).toISOString()`
+       - In JavaScript: `timeText = new Date(timestamp).toISOString()`
        - In Go format: `2006-01-02T15:04:05.000Z`
  *
- * - The signed message of the upload of a piece is:
- *     - `<Bytes>DDC upload ${CID} at ${timeText}</Bytes>`
+ * - The signed message to store a piece is:
+ *     - `<Bytes>DDC store ${CID} at ${timeText}</Bytes>`
  *     - Note: the `<Bytes>` part is enforced by the Polkadot.js browser extension.
- *     - Example: `<Bytes>DDC upload bafk2bzacea73ycjnxe2qov7cvnhx52lzfp6nf5jcblnfus6gqreh6ygganbws at 2022-06-27T07:33:44.607Z</Bytes>`
+ *     - Example: `<Bytes>DDC store bafk2bzacea73ycjnxe2qov7cvnhx52lzfp6nf5jcblnfus6gqreh6ygganbws at 2022-06-27T07:33:44.607Z</Bytes>`
  *
  * - The signing scheme should be sr25519, and `scheme` should be empty.
  *     - If this not supported by a signer, then `scheme` should be "ed25519".
@@ -59,7 +59,7 @@ message Signature {
   // Default and recommended value: 0 or 0xb220, meaning blake2b-256.
   uint64 multiHashType = 4;
   // The timestamp in UNIX milliseconds.
-  uint64 timeMs        = 5;
+  uint64 timestamp     = 5;
   // The public key in binary encoding as per the scheme.
   bytes publicKey      = 6;
   // The cryptographic signature in binary encoding as per the scheme.

--- a/storage/protobuf/signature.proto
+++ b/storage/protobuf/signature.proto
@@ -42,16 +42,15 @@ option go_package = "/pb";
  * 
  * #### Legacy signatures before v0.1.4
  * 
- * If `signer` and `value` are present:
- * - Decode them from hexadecimal with or without `0x`, instead of `publicKey` and `sig`.
- * - The signed message is `${CID}` or `<Bytes>${CID}</Bytes>`.
+ * - If `value` is 130 bytes long, and `signer` is 66 bytes long, and they starts with `0x` (UTF-8), decode them from hexadecimal.
+ * - Then, the signed message is `${CID}` or `<Bytes>${CID}</Bytes>`.
  *
  */
 message Signature {
-  // [deprecated] A cryptographic signature in hexadecimal with or without "0x".
-  string value         = 1;
-  // [deprecated] The public key of the signer in hexadecimal with or without "0x".
-  string signer        = 2;
+  // The cryptographic signature in binary encoding as per the scheme.
+  bytes value          = 1;
+  // The public key of the signer in binary encoding as per the scheme.
+  bytes signer         = 2;
   // The name of the signature scheme (sr25519, secp256k1, ed25519).
   // Default and recommended value: "" or "sr25519".
   string scheme        = 3;
@@ -60,8 +59,4 @@ message Signature {
   uint64 multiHashType = 4;
   // The timestamp in UNIX milliseconds.
   uint64 timestamp     = 5;
-  // The public key in binary encoding as per the scheme.
-  bytes publicKey      = 6;
-  // The cryptographic signature in binary encoding as per the scheme.
-  bytes sig            = 7;
 }

--- a/storage/protobuf/signed_piece.proto
+++ b/storage/protobuf/signed_piece.proto
@@ -9,21 +9,6 @@ option go_package = "/pb";
 /*
  * A piece signed by an account.
  * This can be used to verify the intent of the account holder to upload the piece.
- * 
- * #### Generation
- * - Compute a CID from the `piece` bytes using details from `signature`:
- *     - [CIDv1](https://github.com/multiformats/cid)
- *     - Hash function `signature.multiHashType`
- *     - Content type codec `0x55`
- *     - Base encoded in Base32 with the prefix `b`
- * - The signed message is the CID itself.
- * - Sign the message using `signature.scheme`
- * - Store the signature in `signature.value` in hexadecimal with `0x`.
- * 
- * #### Verification
- * - Recompute the signed message.
- * - Decode `signature.value` from hexadecimal with or without `0x`.
- * - Verify the signature of the message using `signature.scheme`.
  */
 message SignedPiece {
   // A Piece message serialized in protobuf.


### PR DESCRIPTION
- Sign a specific and human-readable message.
- Include time of signature. This is not only a best practice, but also important because permissions can change, so we should have the ability to verify permissions as of a past time.
- Save some space and encoding/decoding steps.